### PR TITLE
fix: read the iframe scale via vitest's API

### DIFF
--- a/packages/vitest-browser-commands/package.json
+++ b/packages/vitest-browser-commands/package.json
@@ -40,10 +40,14 @@
     "dev": "tsdown --watch"
   },
   "peerDependencies": {
-    "@vitest/browser-playwright": "^4.0.3",
-    "vitest": "^4.0.3"
+    "@vitest/browser": "^4.0.0 || ^5.0.0-beta.0",
+    "@vitest/browser-playwright": "^4.0.3 || ^5.0.0-beta.0",
+    "vitest": "^4.0.3 || ^5.0.0-beta.0"
   },
   "peerDependenciesMeta": {
+    "@vitest/browser": {
+      "optional": true
+    },
     "@vitest/browser-playwright": {
       "optional": true
     },
@@ -54,6 +58,7 @@
   "devDependencies": {
     "@ocavue/tsconfig": "^0.7.1",
     "@types/node": "^22.19.0",
+    "@vitest/browser": "^4.1.10",
     "@vitest/browser-playwright": "^4.1.10",
     "tsdown": "^0.22.14",
     "typescript": "^6.0.3",

--- a/packages/vitest-browser-commands/package.json
+++ b/packages/vitest-browser-commands/package.json
@@ -40,9 +40,9 @@
     "dev": "tsdown --watch"
   },
   "peerDependencies": {
-    "@vitest/browser": "^4.0.0 || ^5.0.0-beta.0",
-    "@vitest/browser-playwright": "^4.0.3 || ^5.0.0-beta.0",
-    "vitest": "^4.0.3 || ^5.0.0-beta.0"
+    "@vitest/browser": "^4.0.0",
+    "@vitest/browser-playwright": "^4.0.3",
+    "vitest": "^4.0.3"
   },
   "peerDependenciesMeta": {
     "@vitest/browser": {

--- a/packages/vitest-browser-commands/src/playwright/helpers.ts
+++ b/packages/vitest-browser-commands/src/playwright/helpers.ts
@@ -1,6 +1,5 @@
 import { getIframeScale } from '@vitest/browser/locators'
 
-
 function getIframe() {
   // https://github.com/vitest-dev/vitest/blob/v5.0.0-beta.7/packages/browser/src/client/tester/tester-utils.ts#L258
   {
@@ -8,16 +7,15 @@ function getIframe() {
     if (iframe) return iframe
   }
 
-  // https://github.com/vitest-dev/vitest/blob/v4.0.3/packages/browser/src/client/tester/tester-utils.ts#L170
+  // https://github.com/vitest-dev/vitest/blob/v4.1.10/packages/browser/src/client/tester/tester-utils.ts#L227
   {
     const iframe = window.parent.document.querySelector(`iframe[data-vitest]`)
     if (iframe) return iframe
   }
 
-    throw new Error(
-      `Cannot find iframe element. This is a bug in vitest-browser-commands. Please, open a new issue with reproduction.`,
-    )
-
+  throw new Error(
+    `Cannot find iframe element. This is a bug in vitest-browser-commands. Please, open a new issue with reproduction.`,
+  )
 }
 
 /**

--- a/packages/vitest-browser-commands/src/playwright/helpers.ts
+++ b/packages/vitest-browser-commands/src/playwright/helpers.ts
@@ -1,5 +1,25 @@
 import { getIframeScale } from '@vitest/browser/locators'
 
+
+function getIframe() {
+  // https://github.com/vitest-dev/vitest/blob/v5.0.0-beta.7/packages/browser/src/client/tester/tester-utils.ts#L258
+  {
+    const iframe = window.frameElement
+    if (iframe) return iframe
+  }
+
+  // https://github.com/vitest-dev/vitest/blob/v4.0.3/packages/browser/src/client/tester/tester-utils.ts#L170
+  {
+    const iframe = window.parent.document.querySelector(`iframe[data-vitest]`)
+    if (iframe) return iframe
+  }
+
+    throw new Error(
+      `Cannot find iframe element. This is a bug in vitest-browser-commands. Please, open a new issue with reproduction.`,
+    )
+
+}
+
 /**
  * A helper class to transform positions between the page and the iframe.
  */
@@ -9,12 +29,7 @@ export class IframeTransform {
   private iframeScale: number
 
   constructor() {
-    const iframe = window.parent.document.querySelector(`iframe[data-vitest]`)
-    if (!iframe) {
-      throw new Error(
-        `Cannot find iframe element. This is a bug in vitest-browser-commands. Please, open a new issue with reproduction.`,
-      )
-    }
+    const iframe = getIframe()
 
     const rect = iframe.getBoundingClientRect()
 

--- a/packages/vitest-browser-commands/src/playwright/helpers.ts
+++ b/packages/vitest-browser-commands/src/playwright/helpers.ts
@@ -1,3 +1,5 @@
+import { getIframeScale } from '@vitest/browser/locators'
+
 /**
  * A helper class to transform positions between the page and the iframe.
  */
@@ -7,7 +9,6 @@ export class IframeTransform {
   private iframeScale: number
 
   constructor() {
-    // The following code is based on https://github.com/vitest-dev/vitest/blob/v4.0.3/packages/browser/src/client/tester/tester-utils.ts#L170
     const iframe = window.parent.document.querySelector(`iframe[data-vitest]`)
     if (!iframe) {
       throw new Error(
@@ -15,26 +16,11 @@ export class IframeTransform {
       )
     }
 
-    const testerUi = iframe.parentElement
-    if (!testerUi) {
-      throw new Error(
-        `Cannot find Tester element. This is a bug in vitest-browser-commands. Please, open a new issue with reproduction.`,
-      )
-    }
-
-    const scaleAttribute = testerUi.getAttribute('data-scale')
-    const scale = Number(scaleAttribute)
-    if (Number.isNaN(scale)) {
-      throw new TypeError(
-        `Cannot parse scale value from Tester element (${scaleAttribute}). This is a bug in vitest-browser-commands. Please, open a new issue with reproduction.`,
-      )
-    }
-
     const rect = iframe.getBoundingClientRect()
 
     this.iframeX = rect.x
     this.iframeY = rect.y
-    this.iframeScale = scale
+    this.iframeScale = getIframeScale()
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
       '@types/node':
         specifier: ^22.19.0
         version: 22.19.19
-      '@vitest/browser':
-        specifier: ^4.1.10
-        version: 4.1.10(vite@8.2.0(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vitest@4.1.10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@types/node':
         specifier: ^22.19.0
         version: 22.19.19
+      '@vitest/browser':
+        specifier: ^4.1.10
+        version: 4.1.10(vite@8.2.0(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vitest@4.1.10)
@@ -59,6 +62,9 @@ importers:
       '@types/node':
         specifier: ^22.19.0
         version: 22.19.19
+      '@vitest/browser':
+        specifier: ^4.1.10
+        version: 4.1.10(vite@8.2.0(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vitest@4.1.10)

--- a/test/playwright/package.json
+++ b/test/playwright/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@ocavue/tsconfig": "^0.7.1",
     "@types/node": "^22.19.0",
-    "@vitest/browser": "^4.1.10",
     "@vitest/browser-playwright": "^4.1.10",
     "playwright": "^1.62.1",
     "typescript": "^6.0.3",

--- a/test/playwright/package.json
+++ b/test/playwright/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@ocavue/tsconfig": "^0.7.1",
     "@types/node": "^22.19.0",
+    "@vitest/browser": "^4.1.10",
     "@vitest/browser-playwright": "^4.1.10",
     "playwright": "^1.62.1",
     "typescript": "^6.0.3",


### PR DESCRIPTION
`IframeTransform` reads the iframe scale from the tester element's `data-scale` attribute, which vitest 5 no longer sets. In vitest 5 the scale comes from the iframe's own CSS transform.

Read the scale with `getIframeScale()` from `@vitest/browser/locators` instead. Both vitest 4 and vitest 5 export that function, each returning the correct value for its runtime, so this keeps vitest 4 behavior while working on vitest 5.

`@vitest/browser` is added as an optional peer dependency of the package (plus a dev dependency for typechecking), so consumers only keep declaring `@vitest/browser-playwright` as before.
