### PR TITLE
ci: fix npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
         run: pnpm run build
 
       - name: Publish to NPM
-        run: pnpm --filter vitest-browser-commands publish --no-git-checks
+        run: pnpm --filter vitest-browser-commands publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,9 @@ on:
     branches:
       - master
 
-  workflow_dispatch:
-
 jobs:
   version:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
@@ -18,7 +15,7 @@ jobs:
           release-type: node
           path: packages/vitest-browser-commands
     outputs:
-      release_created: ${{ steps.release-please.outputs['packages/vitest-browser-commands--release_created'] }}
+      release_created: ${{ steps.release-please.outputs.releases_created }}
 
   publish:
     runs-on: ubuntu-latest
@@ -26,7 +23,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    if: ${{ !cancelled() && (needs.version.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ needs.version.outputs.release_created == 'true' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,12 @@ on:
     branches:
       - master
 
+  workflow_dispatch:
+
 jobs:
   version:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
@@ -15,7 +18,7 @@ jobs:
           release-type: node
           path: packages/vitest-browser-commands
     outputs:
-      release_created: ${{ steps.release-please.outputs.release_created }}
+      release_created: ${{ steps.release-please.outputs['packages/vitest-browser-commands--release_created'] }}
 
   publish:
     runs-on: ubuntu-latest
@@ -23,7 +26,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    if: ${{ needs.version.outputs.release_created }}
+    if: ${{ !cancelled() && (needs.version.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -33,4 +36,4 @@ jobs:
         run: pnpm run build
 
       - name: Publish to NPM
-        run: pnpm --filter vitest-browser-commands publish
+        run: pnpm --filter vitest-browser-commands publish --no-git-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           release-type: node
           path: packages/vitest-browser-commands
     outputs:
-      release_created: ${{ steps.release-please.outputs.releases_created }}
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
 
   publish:
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    if: ${{ needs.version.outputs.release_created == 'true' }}
+    if: ${{ needs.version.outputs.releases_created == 'true' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
With the `path` input, release-please never sets the plain `release_created` output (only `packages/vitest-browser-commands--release_created` and the aggregate `releases_created`), so the publish job has been skipped since the monorepo migration and neither 0.3.0 nor 0.4.0 reached npm. Read `releases_created` instead, compared to `'true'` because that output is always set and the string `'false'` is truthy in a bare `if:` expression.