### PR TITLE
fix: remove `typesVersions` from `package.json`

### DIFF
--- a/packages/vitest-browser-commands/package.json
+++ b/packages/vitest-browser-commands/package.json
@@ -28,16 +28,6 @@
       "import": "./dist/playwright.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/index.d.ts"
-      ],
-      "playwright": [
-        "./dist/playwright.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
Remove the `typesVersions` field, which is redundant now that types are resolved through the `exports` map.