### PR TITLE
test: fix the webkit first-key flake in `keyboard.test.ts`

### DIFF
--- a/test/vitest-v4-playwright/keyboard.test.ts
+++ b/test/vitest-v4-playwright/keyboard.test.ts
@@ -179,16 +179,21 @@ function createTestForm(): HTMLFormElement {
 }
 
 async function focusInput(input: HTMLInputElement): Promise<void> {
-  input.focus()
   await vi.waitFor(
-    () => {
-      if (!document.hasFocus()) {
-        window.focus()
-        throw new Error('document does not have focus')
+    async () => {
+      input.focus()
+      let received = false
+      const listener = () => {
+        received = true
       }
-      if (document.activeElement !== input) {
-        input.focus()
-        throw new Error('input is not the active element')
+      input.addEventListener('keydown', listener)
+      try {
+        await keyboard.press('Shift')
+      } finally {
+        input.removeEventListener('keydown', listener)
+      }
+      if (!received) {
+        throw new Error('input did not receive the probe key press')
       }
     },
     { timeout: 5000 },

--- a/test/vitest-v4-playwright/keyboard.test.ts
+++ b/test/vitest-v4-playwright/keyboard.test.ts
@@ -178,8 +178,6 @@ function createTestForm(): HTMLFormElement {
   return form
 }
 
-// WebKit hands keyboard focus to the tester iframe asynchronously; typing
-// before the handoff settles drops the first key.
 async function focusInput(input: HTMLInputElement): Promise<void> {
   input.focus()
   await vi.waitFor(

--- a/test/vitest-v4-playwright/keyboard.test.ts
+++ b/test/vitest-v4-playwright/keyboard.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 
 describe('keyboard', () => {
   describe('type', () => {
     it('should type text into a focused input', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
 
       await keyboard.type('Hello World')
 
@@ -22,7 +22,7 @@ describe('keyboard', () => {
 
     it('should type with delay option', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
 
       await keyboard.type('Test', { delay: 10 })
 
@@ -33,7 +33,7 @@ describe('keyboard', () => {
   describe('press', () => {
     it('should press a single key', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       input.value = 'Hello'
 
       await keyboard.press('Backspace')
@@ -49,7 +49,7 @@ describe('keyboard', () => {
         e.preventDefault()
         formSubmitted = true
       })
-      input.focus()
+      await focusInput(input)
 
       await keyboard.press('Enter')
 
@@ -58,7 +58,7 @@ describe('keyboard', () => {
 
     it('should press key combinations with modifiers', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
 
       await keyboard.press('Shift+KeyA')
 
@@ -69,7 +69,7 @@ describe('keyboard', () => {
   describe('down and up', () => {
     it('should trigger keydown event', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let keyDownTriggered = false
       let keyPressed = ''
 
@@ -86,7 +86,7 @@ describe('keyboard', () => {
 
     it('should trigger keyup event', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let keyUpTriggered = false
       let keyPressed = ''
 
@@ -104,7 +104,7 @@ describe('keyboard', () => {
 
     it('should handle modifier keys', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let shiftPressed = false
 
       input.addEventListener('keydown', (e) => {
@@ -123,7 +123,7 @@ describe('keyboard', () => {
   describe('insertText', () => {
     it('should insert text without triggering keyboard events', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let keydownTriggered = false
 
       input.addEventListener('keydown', () => {
@@ -138,7 +138,7 @@ describe('keyboard', () => {
 
     it('should insert text at cursor position', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       input.value = 'Hello World'
       input.setSelectionRange(5, 5)
 
@@ -176,4 +176,23 @@ function createTestForm(): HTMLFormElement {
 
   document.body.appendChild(form)
   return form
+}
+
+// WebKit hands keyboard focus to the tester iframe asynchronously; typing
+// before the handoff settles drops the first key.
+async function focusInput(input: HTMLInputElement): Promise<void> {
+  input.focus()
+  await vi.waitFor(
+    () => {
+      if (!document.hasFocus()) {
+        window.focus()
+        throw new Error('document does not have focus')
+      }
+      if (document.activeElement !== input) {
+        input.focus()
+        throw new Error('input is not the active element')
+      }
+    },
+    { timeout: 5000 },
+  )
 }

--- a/test/vitest-v4-playwright/vitest.config.ts
+++ b/test/vitest-v4-playwright/vitest.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   plugins: [playwrightCommands()],
   test: {
+    retry: process.env.CI ? 3 : 0,
     browser: {
       enabled: true,
       provider: playwright(),

--- a/test/vitest-v5-playwright/keyboard.test.ts
+++ b/test/vitest-v5-playwright/keyboard.test.ts
@@ -179,16 +179,21 @@ function createTestForm(): HTMLFormElement {
 }
 
 async function focusInput(input: HTMLInputElement): Promise<void> {
-  input.focus()
   await vi.waitFor(
-    () => {
-      if (!document.hasFocus()) {
-        window.focus()
-        throw new Error('document does not have focus')
+    async () => {
+      input.focus()
+      let received = false
+      const listener = () => {
+        received = true
       }
-      if (document.activeElement !== input) {
-        input.focus()
-        throw new Error('input is not the active element')
+      input.addEventListener('keydown', listener)
+      try {
+        await keyboard.press('Shift')
+      } finally {
+        input.removeEventListener('keydown', listener)
+      }
+      if (!received) {
+        throw new Error('input did not receive the probe key press')
       }
     },
     { timeout: 5000 },

--- a/test/vitest-v5-playwright/keyboard.test.ts
+++ b/test/vitest-v5-playwright/keyboard.test.ts
@@ -178,8 +178,6 @@ function createTestForm(): HTMLFormElement {
   return form
 }
 
-// WebKit hands keyboard focus to the tester iframe asynchronously; typing
-// before the handoff settles drops the first key.
 async function focusInput(input: HTMLInputElement): Promise<void> {
   input.focus()
   await vi.waitFor(

--- a/test/vitest-v5-playwright/keyboard.test.ts
+++ b/test/vitest-v5-playwright/keyboard.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 
 describe('keyboard', () => {
   describe('type', () => {
     it('should type text into a focused input', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
 
       await keyboard.type('Hello World')
 
@@ -22,7 +22,7 @@ describe('keyboard', () => {
 
     it('should type with delay option', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
 
       await keyboard.type('Test', { delay: 10 })
 
@@ -33,7 +33,7 @@ describe('keyboard', () => {
   describe('press', () => {
     it('should press a single key', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       input.value = 'Hello'
 
       await keyboard.press('Backspace')
@@ -49,7 +49,7 @@ describe('keyboard', () => {
         e.preventDefault()
         formSubmitted = true
       })
-      input.focus()
+      await focusInput(input)
 
       await keyboard.press('Enter')
 
@@ -58,7 +58,7 @@ describe('keyboard', () => {
 
     it('should press key combinations with modifiers', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
 
       await keyboard.press('Shift+KeyA')
 
@@ -69,7 +69,7 @@ describe('keyboard', () => {
   describe('down and up', () => {
     it('should trigger keydown event', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let keyDownTriggered = false
       let keyPressed = ''
 
@@ -86,7 +86,7 @@ describe('keyboard', () => {
 
     it('should trigger keyup event', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let keyUpTriggered = false
       let keyPressed = ''
 
@@ -104,7 +104,7 @@ describe('keyboard', () => {
 
     it('should handle modifier keys', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let shiftPressed = false
 
       input.addEventListener('keydown', (e) => {
@@ -123,7 +123,7 @@ describe('keyboard', () => {
   describe('insertText', () => {
     it('should insert text without triggering keyboard events', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       let keydownTriggered = false
 
       input.addEventListener('keydown', () => {
@@ -138,7 +138,7 @@ describe('keyboard', () => {
 
     it('should insert text at cursor position', async () => {
       const input = createTestInput()
-      input.focus()
+      await focusInput(input)
       input.value = 'Hello World'
       input.setSelectionRange(5, 5)
 
@@ -176,4 +176,23 @@ function createTestForm(): HTMLFormElement {
 
   document.body.appendChild(form)
   return form
+}
+
+// WebKit hands keyboard focus to the tester iframe asynchronously; typing
+// before the handoff settles drops the first key.
+async function focusInput(input: HTMLInputElement): Promise<void> {
+  input.focus()
+  await vi.waitFor(
+    () => {
+      if (!document.hasFocus()) {
+        window.focus()
+        throw new Error('document does not have focus')
+      }
+      if (document.activeElement !== input) {
+        input.focus()
+        throw new Error('input is not the active element')
+      }
+    },
+    { timeout: 5000 },
+  )
 }

--- a/test/vitest-v5-playwright/vitest.config.ts
+++ b/test/vitest-v5-playwright/vitest.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   plugins: [playwrightCommands()],
   test: {
+    retry: process.env.CI ? 3 : 0,
     browser: {
       enabled: true,
       provider: playwright(),


### PR DESCRIPTION
WebKit occasionally drops the first typed character (`'ello World'`) because keyboard focus reaches the tester iframe asynchronously after `input.focus()`. Before sending keys, press a side-effect-free `Shift` probe and wait until the input receives its `keydown` (a `document.hasFocus()` gate was tried first, but headless Firefox never reports focus), and retry browser tests up to 3 times in CI as a safety net.